### PR TITLE
ui: storybook migration to v7

### DIFF
--- a/platform/firecamp-ui/.storybook/main.js
+++ b/platform/firecamp-ui/.storybook/main.js
@@ -1,4 +1,10 @@
 const path = require('path');
+
+/**
+ * TODO: storybook migration to v7 package version upgrade issues
+ * @ref https://github.com/storybookjs/storybook/issues/23385
+ */
+// const config = {
 module.exports = {
   stories: [
     '../src/stories/**/*.stories.mdx',
@@ -6,16 +12,20 @@ module.exports = {
     '../src/stories/**/*.stories.@(js|jsx|ts|tsx)',
     '../src/components/**/*.stories.@(js|jsx|ts|tsx)',
   ],
+
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     '@storybook/addon-jest',
   ],
+
   framework: '@storybook/react',
+
   core: {
     builder: '@storybook/builder-webpack5',
   },
+
   webpackFinal: (config) => {
     // add SCSS support for CSS Modules
     config.module.rules.push({
@@ -76,6 +86,7 @@ module.exports = {
 
     return config;
   },
+
   /**
    * TODO: remove after storybook migration to v7
    * @ref: https://github.com/storybookjs/storybook/issues/21642#issuecomment-1474350363
@@ -84,4 +95,9 @@ module.exports = {
   typescript: {
     reactDocgen: false,
   },
+
+  docs: {
+    autodocs: true,
+  },
 };
+// export default config;

--- a/platform/firecamp-ui/.storybook/preview.js
+++ b/platform/firecamp-ui/.storybook/preview.js
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { withTests } from '@storybook/addon-jest';
-import { addDecorator } from '@storybook/react';
 
 //to access tailwind.scss styles everywhere in project
 import '../src/scss/tailwind.scss';
@@ -10,32 +9,34 @@ import FirecampThemeSelector from '../src/components/theme/FirecampThemeSelector
 import FirecampThemeProvider from '../src/components/theme/FirecampThemeProvider';
 import { EFirecampThemeVariant } from '../src/components/theme/FirecampThemeProvider.interfaces';
 
-export const parameters = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
-  controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/,
+const preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
     },
   },
 };
+
 export const decorators = [
   withTests({
     results,
   }),
+  //adding globally theme-selection
+  (story) => {
+    const [theme, updateTheme] = useState(EFirecampThemeVariant.LightSecondary);
+
+    return (
+      <FirecampThemeProvider themeVariant={theme}>
+        <StoryTheme theme={theme} updateTheme={updateTheme} />
+        {story()}
+      </FirecampThemeProvider>
+    );
+  },
 ];
-
-//adding globally theme-selection
-addDecorator((story) => {
-  const [theme, updateTheme] = useState(EFirecampThemeVariant.LightSecondary);
-
-  return (
-    <FirecampThemeProvider themeVariant={theme}>
-      <StoryTheme theme={theme} updateTheme={updateTheme} />
-      {story()}
-    </FirecampThemeProvider>
-  );
-});
 
 const StoryTheme = ({ theme, updateTheme }) => {
   return (
@@ -44,3 +45,5 @@ const StoryTheme = ({ theme, updateTheme }) => {
     </div>
   );
 };
+
+export default preview;

--- a/platform/firecamp-ui/package.json
+++ b/platform/firecamp-ui/package.json
@@ -76,6 +76,7 @@
     "postcss": "^8.4.21",
     "postcss-cli": "^8.3.1",
     "raw-loader": "^4.0.2",
+    "react": "17.0.2",
     "react-dom": "17.0.2",
     "sass": "^1.54.4",
     "sass-loader": "^13.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -976,9 +976,6 @@ importers:
       re-resizable:
         specifier: ^6.9.9
         version: 6.9.9(react-dom@17.0.2)(react@17.0.2)
-      react:
-        specifier: ^17.0.0
-        version: 17.0.2
       react-codemirror2:
         specifier: ^7.2.1
         version: 7.2.1(codemirror@5.65.11)(react@17.0.2)
@@ -1112,6 +1109,9 @@ importers:
       raw-loader:
         specifier: ^4.0.2
         version: 4.0.2(webpack@5.75.0)
+      react:
+        specifier: 17.0.2
+        version: 17.0.2
       react-dom:
         specifier: 17.0.2
         version: 17.0.2(react@17.0.2)
@@ -4557,7 +4557,7 @@ packages:
       jest-changed-files: 29.2.0
       jest-config: 29.3.1(@types/node@16.18.40)(ts-node@10.9.1)
       jest-haste-map: 29.3.1
-      jest-message-util: 29.5.0
+      jest-message-util: 29.6.2
       jest-regex-util: 29.2.0
       jest-resolve: 29.3.1
       jest-resolve-dependencies: 29.3.1
@@ -4656,20 +4656,6 @@ packages:
       jest-get-type: 28.0.2
     dev: true
 
-  /@jest/expect-utils@29.3.1:
-    resolution: {integrity: sha512-wlrznINZI5sMjwvUoLVk617ll/UYfGIZNxmbU+Pa7wmkL4vYzhV9R2pwVqUh4NWWuLQWkI8+8mOkxs//prKQ3g==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      jest-get-type: 29.4.3
-    dev: true
-
-  /@jest/expect-utils@29.5.0:
-    resolution: {integrity: sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      jest-get-type: 29.4.3
-    dev: true
-
   /@jest/expect-utils@29.6.2:
     resolution: {integrity: sha512-6zIhM8go3RV2IG4aIZaZbxwpOzz3ZiM23oxAlkquOIole+G6TrbeXnykxWYlqF7kz2HlBjdKtca20x9atkEQYg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4726,7 +4712,7 @@ packages:
       '@jest/types': 29.6.1
       '@sinonjs/fake-timers': 9.1.2
       '@types/node': 16.18.40
-      jest-message-util: 29.5.0
+      jest-message-util: 29.6.2
       jest-mock: 29.3.1
       jest-util: 29.6.2
     dev: true
@@ -4893,13 +4879,6 @@ packages:
   /@jest/schemas@28.1.3:
     resolution: {integrity: sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.24.51
-    dev: true
-
-  /@jest/schemas@29.0.0:
-    resolution: {integrity: sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@sinclair/typebox': 0.24.51
     dev: true
@@ -15370,21 +15349,21 @@ packages:
     resolution: {integrity: sha512-gGb1yTgU30Q0O/tQq+z30KBWv24ApkMgFUpvKBkyLUBL68Wv8dHdJxTBZFl/iT8K/bqDHvUYRH6IIN3rToopPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/expect-utils': 29.3.1
-      jest-get-type: 29.2.0
-      jest-matcher-utils: 29.3.1
-      jest-message-util: 29.3.1
-      jest-util: 29.3.1
+      '@jest/expect-utils': 29.6.2
+      jest-get-type: 29.4.3
+      jest-matcher-utils: 29.6.2
+      jest-message-util: 29.6.2
+      jest-util: 29.6.2
     dev: true
 
   /expect@29.5.0:
     resolution: {integrity: sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/expect-utils': 29.5.0
+      '@jest/expect-utils': 29.6.2
       jest-get-type: 29.4.3
-      jest-matcher-utils: 29.5.0
-      jest-message-util: 29.5.0
+      jest-matcher-utils: 29.6.2
+      jest-message-util: 29.6.2
       jest-util: 29.6.2
     dev: true
 
@@ -19233,11 +19212,6 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dev: true
 
-  /jest-get-type@29.2.0:
-    resolution: {integrity: sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dev: true
-
   /jest-get-type@29.4.3:
     resolution: {integrity: sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -19367,26 +19341,6 @@ packages:
       pretty-format: 28.1.3
     dev: true
 
-  /jest-matcher-utils@29.3.1:
-    resolution: {integrity: sha512-fkRMZUAScup3txIKfMe3AIZZmPEjWEdsPJFK3AIy5qRohWqQFg1qrmKfYXR9qEkNc7OdAu2N4KPHibEmy4HPeQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      chalk: 4.1.2
-      jest-diff: 29.6.2
-      jest-get-type: 29.4.3
-      pretty-format: 29.6.2
-    dev: true
-
-  /jest-matcher-utils@29.5.0:
-    resolution: {integrity: sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      chalk: 4.1.2
-      jest-diff: 29.6.2
-      jest-get-type: 29.4.3
-      pretty-format: 29.6.2
-    dev: true
-
   /jest-matcher-utils@29.6.2:
     resolution: {integrity: sha512-4LiAk3hSSobtomeIAzFTe+N8kL6z0JtF3n6I4fg29iIW7tt99R7ZcIFW34QkX+DuVrf+CUe6wuVOpm7ZKFJzZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -19408,36 +19362,6 @@ packages:
       graceful-fs: 4.2.11
       micromatch: 4.0.5
       pretty-format: 28.1.3
-      slash: 3.0.0
-      stack-utils: 2.0.6
-    dev: true
-
-  /jest-message-util@29.3.1:
-    resolution: {integrity: sha512-lMJTbgNcDm5z+6KDxWtqOFWlGQxD6XaYwBqHR8kmpkP+WWWG90I35kdtQHY67Ay5CSuydkTBbJG+tH9JShFCyA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@jest/types': 29.6.1
-      '@types/stack-utils': 2.0.1
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      micromatch: 4.0.5
-      pretty-format: 29.6.2
-      slash: 3.0.0
-      stack-utils: 2.0.6
-    dev: true
-
-  /jest-message-util@29.5.0:
-    resolution: {integrity: sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@jest/types': 29.6.1
-      '@types/stack-utils': 2.0.1
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      micromatch: 4.0.5
-      pretty-format: 29.6.2
       slash: 3.0.0
       stack-utils: 2.0.6
     dev: true
@@ -19962,18 +19886,6 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 16.18.40
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      graceful-fs: 4.2.11
-      picomatch: 2.3.1
-    dev: true
-
-  /jest-util@29.3.1:
-    resolution: {integrity: sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/types': 29.6.1
       '@types/node': 16.18.40
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -23852,7 +23764,7 @@ packages:
     resolution: {integrity: sha512-FyLnmb1cYJV8biEIiRyzRFvs2lry7PPIvOqKVe1GCUEYg4YGmlx1qG9EJNMxArYm7piII4qb8UV1Pncq5dxmcg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/schemas': 29.0.0
+      '@jest/schemas': 29.6.0
       ansi-styles: 5.2.0
       react-is: 18.2.0
     dev: true
@@ -23861,7 +23773,7 @@ packages:
     resolution: {integrity: sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/schemas': 29.4.3
+      '@jest/schemas': 29.6.0
       ansi-styles: 5.2.0
       react-is: 18.2.0
     dev: true


### PR DESCRIPTION
storybook v7 migration issue

after running the storybook upgrade script https://storybook.js.org/docs/react/configure/upgrading#upgrade-script
1. Auto-migration & Manual-migrations are done successfully

2. But Storybook package versions in package.json file are not being updated to v7
    
      ```
            Error: npm ERR! Cannot set property 'peer' of null
       ```
          
- this issue is open at the storybook repo: https://github.com/storybookjs/storybook/issues/23385


---
blocked by https://github.com/storybookjs/storybook/issues/23385