### PR TITLE
fix(server) : Added Proper Escaping quotes in scripts:'build' to work…

### DIFF
--- a/playgrounds/firecamp-socket-io-executor/package.json
+++ b/playgrounds/firecamp-socket-io-executor/package.json
@@ -6,7 +6,7 @@
   "license": "",
   "keywords": [],
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "clean": "rimraf dist/",
     "fix": "run-s fix:*",

--- a/playgrounds/firecamp-ws-executor/package.json
+++ b/playgrounds/firecamp-ws-executor/package.json
@@ -9,7 +9,7 @@
   "license": "",
   "keywords": [],
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "clean": "rimraf dist/",
     "fix": "run-s fix:*",


### PR DESCRIPTION
Issue: Dev Server Not Starting up from powershell because of escaping charectors in scripts: Build ("build": "run-p 'build:*'")
Solution : https://stackoverflow.com/questions/70306554/pnpm-run-on-multiples-projects-based-on-location .
"build": "run-p 'build:'" in the services : firecamp-socket-io-executor,firecamp-ws-executor is not escaping single quotes properly while starting the dev . I resolved it by "run-p "build:" , then its starting up 
![image](https://github.com/firecamp-dev/firecamp/assets/116077457/7f29d2a2-e08c-4da6-a80f-f4d44f223508)
