### PR TITLE
fix(server) : Added Proper Escaping quotes in scripts:'build' to work…

### DIFF
--- a/playgrounds/firecamp-socket-io-executor/package.json
+++ b/playgrounds/firecamp-socket-io-executor/package.json
@@ -6,7 +6,7 @@
   "license": "",
   "keywords": [],
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "clean": "rimraf dist/",
     "fix": "run-s fix:*",

--- a/playgrounds/firecamp-ws-executor/package.json
+++ b/playgrounds/firecamp-ws-executor/package.json
@@ -9,7 +9,7 @@
   "license": "",
   "keywords": [],
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "clean": "rimraf dist/",
     "fix": "run-s fix:*",


### PR DESCRIPTION
Issue:  Dev Server is not starting up  from powershell cmd because of 'build' in the scripts 
Resolution: this is happening because from powershell it properly not escaping build in "build": "run-p \"build:*\""
https://stackoverflow.com/questions/70306554/pnpm-run-on-multiples-projects-based-on-location 
![image](https://github.com/firecamp-dev/firecamp/assets/116077457/0800297e-c15e-43d4-a0af-e1206ce0cf1a)
