### PR TITLE
Fix/67 dev server not starting from powershell

### DIFF
--- a/playgrounds/firecamp-socket-io-executor/package.json
+++ b/playgrounds/firecamp-socket-io-executor/package.json
@@ -6,7 +6,7 @@
   "license": "",
   "keywords": [],
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "clean": "rimraf dist/",
     "fix": "run-s fix:*",

--- a/playgrounds/firecamp-ws-executor/package.json
+++ b/playgrounds/firecamp-ws-executor/package.json
@@ -9,7 +9,7 @@
   "license": "",
   "keywords": [],
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "clean": "rimraf dist/",
     "fix": "run-s fix:*",


### PR DESCRIPTION
Issue: Dev server not starting 
Resolution: its not starting from powershell cmd (Windows) Becaause of  build in "build": "run-p \"build:*\"" . 
Server is not able properly espace single quotes , this PR solves that . 
Reference: https://stackoverflow.com/questions/70306554/pnpm-run-on-multiples-projects-based-on-location 
![image](https://github.com/firecamp-dev/firecamp/assets/116077457/79b91752-8e32-461d-a4f3-569949335f69)
