### PR TITLE
fix(server-ui):issue-67 Added Proper Escaping quotes in scripts:'build' to work in powershell

### DIFF
--- a/packages/firecamp-agent-manager/package.json
+++ b/packages/firecamp-agent-manager/package.json
@@ -7,7 +7,7 @@
   "keywords": [],
   "main": "src/index.ts",
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.json",
     "clean": "rimraf dist/",
     "fix": "run-s fix:*",

--- a/packages/firecamp-cookie-manager/package.json
+++ b/packages/firecamp-cookie-manager/package.json
@@ -7,7 +7,7 @@
   "license": "",
   "keywords": [],
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.json",
     "clean": "rimraf build/",
     "fix": "run-s fix:*",

--- a/playgrounds/firecamp-socket-io-executor/package.json
+++ b/playgrounds/firecamp-socket-io-executor/package.json
@@ -6,7 +6,7 @@
   "license": "",
   "keywords": [],
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "clean": "rimraf dist/",
     "fix": "run-s fix:*",

--- a/playgrounds/firecamp-ws-executor/package.json
+++ b/playgrounds/firecamp-ws-executor/package.json
@@ -9,7 +9,7 @@
   "license": "",
   "keywords": [],
   "scripts": {
-    "build": "run-p 'build:*'",
+    "build": "run-p \"build:*\"",
     "build:main": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "clean": "rimraf dist/",
     "fix": "run-s fix:*",


### PR DESCRIPTION
Issue: Dev server not starting
Resolution: its not starting from powershell cmd (Windows) Becaause of build in "build": "run-p "build:*"" .
Server is not able properly espace single quotes , this PR solves that .
Reference: https://stackoverflow.com/questions/70306554/pnpm-run-on-multiples-projects-based-on-location
![image](https://github.com/firecamp-dev/firecamp/assets/116077457/84255d94-67bb-43cc-b42b-49609455a680)
