### PR TITLE
feat(ui enhancemenet): Added And Retreived ColorScheme from LocalStorage

### DIFF
--- a/platform/firecamp-ui/src/components/theme/FirecampThemeProvider.tsx
+++ b/platform/firecamp-ui/src/components/theme/FirecampThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useRef, useState } from 'react';
 import {
   ColorScheme,
   ColorSchemeProvider,
@@ -75,21 +75,28 @@ export const useFirecampStyle = createStyles((theme) => ({
 }));
 
 const FirecampThemeProvider: FC<IFirecampThemeProvider> = ({
-  themeVariant = EFirecampThemeVariant.LightPrimary,
+themeVariant = EFirecampThemeVariant.LightPrimary,
   children,
   ...props
 }) => {
-  const [colorScheme, setColorScheme] = useState<ColorScheme>('light');
+    const [colorScheme, setColorScheme] = useState<ColorScheme>('light');
   const [themeColor, updatethemeColor] = useState<EFirecampThemeVariant>(
     EFirecampThemeVariant.LightPrimary
   );
-
+  const [isLocalStorageColorSchemeAssigned,setIsLocalStorageColorSchemeAssigned] = useState(true); // Track if colorScheme has been selected from localStorage only upon refresh
   useEffect(() => {
     updateTheme(themeVariant);
   }, [themeVariant]);
 
   // update theme colorScheme & primaryColor
   const updateTheme = (color: EFirecampThemeVariant) => {
+    //If colorScheme Exists in LocalStorage And First Time Assinging A a color scheme after loading 
+    const storedValue = localStorage.getItem("colorScheme");
+      if (isLocalStorageColorSchemeAssigned && storedValue) {
+        color = Object.values(EFirecampThemeVariant).find(value => value === storedValue);
+        setIsLocalStorageColorSchemeAssigned(false)
+      }
+  
     // update the primary color
     updatethemeColor(color);
 
@@ -110,8 +117,9 @@ const FirecampThemeProvider: FC<IFirecampThemeProvider> = ({
     ].includes(color)
       ? EEditorTheme.Lite
       : EEditorTheme.Dark;
-
+        
     localStorage.setItem('editorTheme', editorTheme);
+    localStorage.setItem("colorScheme",color)
     EditorApi.setEditorTheme(editorTheme);
   };
 

--- a/platform/firecamp-ui/src/components/theme/FirecampThemeProvider.tsx
+++ b/platform/firecamp-ui/src/components/theme/FirecampThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useRef, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import {
   ColorScheme,
   ColorSchemeProvider,

--- a/platform/firecamp-ui/src/components/theme/FirecampThemeSelector.tsx
+++ b/platform/firecamp-ui/src/components/theme/FirecampThemeSelector.tsx
@@ -35,9 +35,9 @@ const FirecampThemeSelector = () => {
   const _setTheme = (t: any) => {
     try {
       // Set app body theme - for matching tailwind theme
-      document.body.className = `theme-${t.split('-')[0] || 'light'} primary-${
-        t.split('-')[1] || 'orange'
-      }`;
+      const themeMode = t.split('-')[0] || 'light';
+      const themeColor = t.split('-')[1] === 'primary' ? 'orange' : 'green';
+      document.body.className = `theme-${themeMode} primary-${themeColor}`;
     } catch (error) {
       console.log({ error });
     }
@@ -47,6 +47,7 @@ const FirecampThemeSelector = () => {
   const activeTheme = ThemeOptions.find(
     (t) => t.value === (colorScheme as EFirecampThemeVariant)
   );
+  if (!activeTheme) return <></>;
   return (
     <DropdownMenu
       onOpenChange={(v) => toggleOpen(v)}


### PR DESCRIPTION
Issue: https://github.com/firecamp-dev/firecamp/issues/60 and https://github.com/firecamp-dev/firecamp/issues/45
Current Behaviour : 
User is not able to save theme .
User Is Not Able To Save ColorSchema .
Resolution : 
It is happening because selection of colors is overriding theme  from localStorage. 
Store the colorschema in localStorage which ensures colors and theme to persist.
[Firecamp, The API Campsite for Developers_.webm](https://github.com/firecamp-dev/firecamp/assets/116077457/cea7ad48-88a2-45eb-a0ee-d7cf36eb1fe2)

