### PR TITLE
ui(icon): chaging to lucide-icon

### DIFF
--- a/platform/firecamp-platform/src/components/status-bar/StatusBarContainer.tsx
+++ b/platform/firecamp-platform/src/components/status-bar/StatusBarContainer.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { VscRemote } from '@react-icons/all-files/vsc/VscRemote';
+import { Flame } from 'lucide-react';
 import { EFirecampAgent } from '@firecamp/types';
 import { StatusBar } from '@firecamp/ui';
 import { _misc } from '@firecamp/utils';
@@ -22,7 +22,7 @@ const StatusBarContainer: FC<any> = ({ className = '' }) => {
           id={'status-bar-firecamp-version'}
           data-tip={`Firecamp`}
         >
-          <VscRemote size={12} />
+          <Flame size={12} />
           <span className="pl-1">Firecamp</span>
         </div>
         <DDMenuContainer />


### PR DESCRIPTION
ui #15 

Previous Icon - 
![image](https://github.com/firecamp-dev/firecamp/assets/77228603/2fbc0640-4dac-4043-b955-6a08a48686f8)

Updated Icon - 
![image](https://github.com/firecamp-dev/firecamp/assets/77228603/0612d8b6-b233-4c3a-bae8-d5f4e1f47ba5)

Changing icons into lucide icon