### PR TITLE
Fix/restrict same name folder creation

### DIFF
--- a/platform/firecamp-platform/src/components/activity-bar/explorer/menus/CollectionMenu.tsx
+++ b/platform/firecamp-platform/src/components/activity-bar/explorer/menus/CollectionMenu.tsx
@@ -67,20 +67,17 @@ const CollectionMenu = ({
 
             const existingFolders = useExplorerStore.getState().explorer.folders;
             const parentFolderId = folderId || collectionId;
-            // console.log(parentFolderId, "parentfolderid")
             const isDuplicateName = existingFolders.some(
-            (folder) =>
-            // console.log(`folder name ${folder.name} and folder parent id ${folder.__ref.collectionId}`),
-            
+            (folder) =>            
               folder.name === val && folder.__ref.collectionId === parentFolderId
-          );
+            );
 
-          if (isDuplicateName) {
-            return {
-              isValid: false,
-              message: 'A folder with the same name already exists in this location.',
-            };
-          }
+            if (isDuplicateName) {
+              return {
+                isValid: false,
+                message: 'A folder with the same name already exists in this location.',
+              };
+            }
             return {
               isValid,
               message:

--- a/platform/firecamp-platform/src/components/activity-bar/explorer/menus/CollectionMenu.tsx
+++ b/platform/firecamp-platform/src/components/activity-bar/explorer/menus/CollectionMenu.tsx
@@ -45,7 +45,7 @@ const CollectionMenu = ({
     prefix: () => <FolderPlus size={14} />,
     name: 'Add Folder',
     onClick: () => {
-      console.log(collectionId, folderId);
+      // console.log(collectionId, folderId);
       if (!platformContext.app.user.isLoggedIn()) {
         return platformContext.app.modals.openSignIn();
       }
@@ -64,6 +64,23 @@ const CollectionMenu = ({
               };
             }
             const isValid = Regex.FolderName.test(val);
+
+            const existingFolders = useExplorerStore.getState().explorer.folders;
+            const parentFolderId = folderId || collectionId;
+            // console.log(parentFolderId, "parentfolderid")
+            const isDuplicateName = existingFolders.some(
+            (folder) =>
+            // console.log(`folder name ${folder.name} and folder parent id ${folder.__ref.collectionId}`),
+            
+              folder.name === val && folder.__ref.collectionId === parentFolderId
+          );
+
+          if (isDuplicateName) {
+            return {
+              isValid: false,
+              message: 'A folder with the same name already exists in this location.',
+            };
+          }
             return {
               isValid,
               message:


### PR DESCRIPTION
This PR fixed the issue of the user not being allowed to create folders with the same name inside a single collection #141

here's the recording to check out how it's working now.

https://www.loom.com/share/063aab3224d7414b9a9ccd608938846c?sid=10fe8c3f-1c89-466b-a8b0-22a223458b23


