### PR TITLE
fix(desktop-app): missing window frame

### DIFF
--- a/packages/firecamp-electron/src/main.ts
+++ b/packages/firecamp-electron/src/main.ts
@@ -16,7 +16,7 @@ const appUpdater = new AppUpdater();
 const createWindow = () => {
   const { width, height } = screen.getPrimaryDisplay().workAreaSize;
   const win = new BrowserWindow({
-    frame: false,
+    frame: true,
     width,
     height,
     icon: nativeImage.createFromPath(appIcon),


### PR DESCRIPTION
Sets frame property on window creation true as outlined in: https://github.com/firecamp-dev/firecamp/issues/186