### PR TITLE
fix: Stop upgrading http requests to https automatically from browser context

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -37,10 +37,6 @@
     <meta name="twitter:image" content="https://firecamp.io/og.jpg" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="upgrade-insecure-requests"
-    />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Addresses https://github.com/firecamp-dev/firecamp/issues/243

Previously, it was not possible to make a http request from the web client as the request would be transparently upgraded to https. This was consequence of an applied content security policy header with a directive to upgrade insecure requests.

This change removes this CSP tag, meaning http requests are no longer forcibly upgraded.